### PR TITLE
Add Barracuda GPU worker supports

### DIFF
--- a/Assets/Scripts/DetectorYolo2.cs
+++ b/Assets/Scripts/DetectorYolo2.cs
@@ -58,9 +58,52 @@ public class DetectorYolo2 : MonoBehaviour, Detector
             .Where(s => !String.IsNullOrEmpty(s)).ToArray();
         var model = ModelLoader.Load(this.modelFile);
         // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/Worker.html
-        // var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-        var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-        this.worker = WorkerFactory.CreateWorker(workerType, model);
+        //These checks all check for GPU before CPU as GPU is preferred if the platform + rendering pipeline support it
+
+#if UNITY_IOS //Only IOS
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
+        {
+            //IOS 11 needed for ARKit, IOS 11 has Metal support only, therefore GPU can run
+            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+        else
+        {
+            //If Metal support is dropped for some reason, fall back to CPU
+            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+
+#elif UNITY_ANDROID //Only Android
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
+        {
+            //Vulkan on Android supports GPU
+            //However, ARCore does not currently support Vulkan, when it does, this line will work
+            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+        else
+        {
+            //If not vulkan, fall back to CPU
+            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+
+#elif UNITY_WEBGL //Only WebGL
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+     //WebGL only supports CPU
+    var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+    this.worker = WorkerFactory.CreateWorker(workerType, model);
+
+#else //Any other platform
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+    // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/SupportedPlatforms.html
+    //var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+      var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+      this.worker = WorkerFactory.CreateWorker(workerType, model);
+#endif
     }
 
 

--- a/Assets/Scripts/DetectorYolo2.cs
+++ b/Assets/Scripts/DetectorYolo2.cs
@@ -48,7 +48,6 @@ public class DetectorYolo2 : MonoBehaviour, Detector
         // 1.08F, 1.19F, 3.42F, 4.41F, 6.63F, 11.38F, 9.42F, 5.11F, 16.62F, 10.52F  // yolov2-tiny-voc
         //0.57273F, 0.677385F, 1.87446F, 2.06253F, 3.33843F, 5.47434F, 7.88282F, 3.52778F, 9.77052F, 9.16828F // yolov2-tiny
         0.57273F, 0.677385F, 1.87446F, 2.06253F, 3.33843F, 5.47434F, 7.88282F, 3.52778F, 9.77052F, 9.16828F  // yolov2-tiny-food
-        //0.57273F, 0.677385F, 1.87446F, 2.06253F, 3.33843F, 5.47434F, 7.88282F, 3.52778F, 9.77052F, 9.16828F // yolov3
     };
 
 
@@ -59,51 +58,7 @@ public class DetectorYolo2 : MonoBehaviour, Detector
         var model = ModelLoader.Load(this.modelFile);
         // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/Worker.html
         //These checks all check for GPU before CPU as GPU is preferred if the platform + rendering pipeline support it
-
-#if UNITY_IOS //Only IOS
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
-        {
-            //IOS 11 needed for ARKit, IOS 11 has Metal support only, therefore GPU can run
-            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-        else
-        {
-            //If Metal support is dropped for some reason, fall back to CPU
-            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-
-#elif UNITY_ANDROID //Only Android
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
-        {
-            //Vulkan on Android supports GPU
-            //However, ARCore does not currently support Vulkan, when it does, this line will work
-            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-        else
-        {
-            //If not vulkan, fall back to CPU
-            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-
-#elif UNITY_WEBGL //Only WebGL
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-     //WebGL only supports CPU
-    var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-    this.worker = WorkerFactory.CreateWorker(workerType, model);
-
-#else //Any other platform
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-    // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/SupportedPlatforms.html
-    //var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-      var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-      this.worker = WorkerFactory.CreateWorker(workerType, model);
-#endif
+        this.worker = GraphicsWorker.GetWorker(model);
     }
 
 

--- a/Assets/Scripts/DetectorYolo3.cs
+++ b/Assets/Scripts/DetectorYolo3.cs
@@ -51,10 +51,6 @@ public class DetectorYolo3 : MonoBehaviour, Detector
 
     private float[] anchors = new float[]
     {
-        // 1.08F, 1.19F, 3.42F, 4.41F, 6.63F, 11.38F, 9.42F, 5.11F, 16.62F, 10.52F  // yolov2-tiny-voc
-        //0.57273F, 0.677385F, 1.87446F, 2.06253F, 3.33843F, 5.47434F, 7.88282F, 3.52778F, 9.77052F, 9.16828F // yolov2-tiny
-        //0.57273F, 0.677385F, 1.87446F, 2.06253F, 3.33843F, 5.47434F, 7.88282F, 3.52778F, 9.77052F, 9.16828F  // yolov2-tiny-food
-        //0.57273F, 0.677385F, 1.87446F, 2.06253F, 3.33843F, 5.47434F, 7.88282F, 3.52778F, 9.77052F, 9.16828F // yolov3
         10F, 14F,  23F, 27F,  37F, 58F,  81F, 82F,  135F, 169F,  344F, 319F // yolov3-tiny
     };
 
@@ -66,53 +62,7 @@ public class DetectorYolo3 : MonoBehaviour, Detector
         var model = ModelLoader.Load(this.modelFile);
         // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/Worker.html
         //These checks all check for GPU before CPU as GPU is preferred if the platform + rendering pipeline support it
-
-#if UNITY_IOS //Only IOS
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
-        {
-            //IOS 11 needed for ARKit, IOS 11 has Metal support only, therefore GPU can run
-            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-        else
-        {
-            //If Metal support is dropped for some reason, fall back to CPU
-            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-
-#elif UNITY_ANDROID //Only Android
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
-        {
-            //Vulkan on Android supports GPU
-            //However, ARCore does not currently support Vulkan, when it does, this line will work
-            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-        else
-        {
-            //If not vulkan, fall back to CPU
-            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-            this.worker = WorkerFactory.CreateWorker(workerType, model);
-        }
-
-#elif UNITY_WEBGL //Only WebGL
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-    //WebGL only supports CPU
-    var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-    this.worker = WorkerFactory.CreateWorker(workerType, model);
-
-#else //Any other platform
-        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
-    // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/SupportedPlatforms.html
-    //var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-      var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-      this.worker = WorkerFactory.CreateWorker(workerType, model);
-#endif
-
-
+        this.worker = GraphicsWorker.GetWorker(model);
     }
 
 

--- a/Assets/Scripts/DetectorYolo3.cs
+++ b/Assets/Scripts/DetectorYolo3.cs
@@ -65,9 +65,54 @@ public class DetectorYolo3 : MonoBehaviour, Detector
             .Where(s => !String.IsNullOrEmpty(s)).ToArray();
         var model = ModelLoader.Load(this.modelFile);
         // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/Worker.html
-        //var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
-        var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
-        this.worker = WorkerFactory.CreateWorker(workerType, model);
+        //These checks all check for GPU before CPU as GPU is preferred if the platform + rendering pipeline support it
+
+#if UNITY_IOS //Only IOS
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
+        {
+            //IOS 11 needed for ARKit, IOS 11 has Metal support only, therefore GPU can run
+            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+        else
+        {
+            //If Metal support is dropped for some reason, fall back to CPU
+            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+
+#elif UNITY_ANDROID //Only Android
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+        if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
+        {
+            //Vulkan on Android supports GPU
+            //However, ARCore does not currently support Vulkan, when it does, this line will work
+            var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+        else
+        {
+            //If not vulkan, fall back to CPU
+            var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+            this.worker = WorkerFactory.CreateWorker(workerType, model);
+        }
+
+#elif UNITY_WEBGL //Only WebGL
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+    //WebGL only supports CPU
+    var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+    this.worker = WorkerFactory.CreateWorker(workerType, model);
+
+#else //Any other platform
+        Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+    // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/SupportedPlatforms.html
+    //var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+      var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+      this.worker = WorkerFactory.CreateWorker(workerType, model);
+#endif
+
+
     }
 
 

--- a/Assets/Scripts/GraphicsWorker.cs
+++ b/Assets/Scripts/GraphicsWorker.cs
@@ -1,0 +1,59 @@
+
+using UnityEngine;
+using System.Collections;
+using Unity.Barracuda;
+
+public class GraphicsWorker: MonoBehaviour
+{
+
+  public static IWorker GetWorker(Model model)
+  {
+    IWorker worker;
+    #if UNITY_IOS //Only IOS
+            Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+            if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Metal)
+            {
+                //IOS 11 needed for ARKit, IOS 11 has Metal support only, therefore GPU can run
+                var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+                worker = WorkerFactory.CreateWorker(workerType, model);
+            }
+            else
+            {
+                //If Metal support is dropped for some reason, fall back to CPU
+                var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+                worker = WorkerFactory.CreateWorker(workerType, model);
+            }
+
+    #elif UNITY_ANDROID //Only Android
+            Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+            if (SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Vulkan)
+            {
+                //Vulkan on Android supports GPU
+                //However, ARCore does not currently support Vulkan, when it does, this line will work
+                var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+                worker = WorkerFactory.CreateWorker(workerType, model);
+            }
+            else
+            {
+                //If not vulkan, fall back to CPU
+                var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+                worker = WorkerFactory.CreateWorker(workerType, model);
+            }
+
+    #elif UNITY_WEBGL //Only WebGL
+            Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+         //WebGL only supports CPU
+        var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+        worker = WorkerFactory.CreateWorker(workerType, model);
+
+    #else //Any other platform
+            Debug.Log("Graphics API: " + SystemInfo.graphicsDeviceType);
+        // https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/SupportedPlatforms.html
+        //var workerType = WorkerFactory.Type.CSharpBurst;  // CPU
+          var workerType = WorkerFactory.Type.ComputePrecompiled; // GPU
+          worker = WorkerFactory.CreateWorker(workerType, model);
+    #endif
+
+    return worker;
+  }
+}

--- a/Assets/Scripts/GraphicsWorker.cs.meta
+++ b/Assets/Scripts/GraphicsWorker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de84e7eab47ff4147ac603d0269538ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Only 2 files should be changed here - both the Detector.cs scripts

All logic is following the supported platforms from here https://docs.unity3d.com/Packages/com.unity.barracuda@1.0/manual/SupportedPlatforms.html

Added platform and rendering system checks to see if the platform allows CPU/GPU
Currently IOS has full GPU support with Metal API on IOS11 for all support ARKit Devices
However, Android Vulka has GPU support but ARCore currently does not support Vulkan
IOS:GPU support is enabled if we are using metal if not fall back to CPU
Android:GPU support will be enabled if the device is running Vulkan, if not fall back to CPU